### PR TITLE
Handle non-plainobjects

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,12 +40,10 @@ function patch (client) {
   originalQuery = originalQuery.bind(client);
 
   var patchedQuery = function(config, values, callback) {
-    //Handle the arity 1 case.
-    if (!values && !callback) {
+    if (arguments.length === 1) {
       return originalQuery(config);
     }
-    //Handle the arity 2 case.
-    else if (!callback && _.isFunction(values)) {
+    else if (arguments.length === 2 && _.isFunction(values)) {
       return originalQuery(config, values);
     }
     else if (_.isArray(values)) {


### PR DESCRIPTION
Having an object which has a constructor other than Object is perfectly valid.
You just don't want to try and reparameterize an array or a function.
