### PR TITLE
if values is undefined or null use original query function

### DIFF
--- a/main.js
+++ b/main.js
@@ -49,7 +49,7 @@ function patch (client) {
     else if (arguments.length === 2 && _.isFunction(values)) {
       return originalQuery(config, values);
     }
-    else if (_.isArray(values)) {
+    else if (_.isUndefined(values) || _.isNull(values) || _.isArray(values)) {
       return originalQuery(config, values, callback);
     } else {
       var reparameterized = numericFromNamed(config, values);


### PR DESCRIPTION
Hi,

thanks for this monkey patch!

The current code fails for:

```
                    pg
                    .query(db_query, null, function(err, result) {
                            callback(err, result.rows);
                        });
```

with

```
 Uncaught TypeError: Object.keys called on non-object
  at Function.keys (native)
  at numericFromNamed (/Users/ca/devel/git/ts_backend/node_modules/node-postgres-named/main.js:6:31)
  at patchedQuery [as query] (/Users/ca/devel/git/ts_backend/node_modules/node-postgres-named/main.js:55:29)
```

This pull request checks whether the second parameter is null or undefined (if there are 3 parameters) and uses the original function in that case, as well.
