### PR TITLE
More permissive engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": false,
   "main": "./main",
   "engines": {
-    "node": "~0.10.21",
-    "npm": "~1.3.11"
+    "iojs": ">= 1",
+    "node": ">= 0.10",
+    "npm": ">= 1"
   },
   "dependencies": {
     "lodash": "~2.3.0"


### PR DESCRIPTION
This library depends on very few things in node or npm, it's safe to allow for
a broader swath of supported engines. Before this, warnings are displayed when
using iojs, node 0.12 or npm 2+.